### PR TITLE
Referenced object store refactoring

### DIFF
--- a/Sources/Puredux/Store/Core/StoreNodeExtensions.swift
+++ b/Sources/Puredux/Store/Core/StoreNodeExtensions.swift
@@ -38,9 +38,7 @@ extension StoreNode {
     }
 
     func strongRefStore() -> Store<State, Action> {
-        Store.referencedStore(dispatch: { [self] in self.dispatch($0) },
-                              subscribe: { [self] in self.subscribe(observer: $0) }
-        )
+        Store<State, Action>(storeObject: self)
     }
 }
 

--- a/Sources/Puredux/Store/Core/StoreNodeExtensions.swift
+++ b/Sources/Puredux/Store/Core/StoreNodeExtensions.swift
@@ -29,19 +29,7 @@ extension StoreNode where LocalState == State {
         )
     }
 }
-
-extension StoreNode {
-    func weakRefStore() -> Store<State, Action> {
-        Store(dispatch: { [weak self] in self?.dispatch($0) },
-              subscribe: { [weak self] in self?.subscribe(observer: $0) }
-        )
-    }
-
-    func strongRefStore() -> Store<State, Action> {
-        Store<State, Action>(storeObject: self)
-    }
-}
-
+ 
 extension StoreNode {
 
     func createChildStore<NodeState, ResultState>(initialState: NodeState,

--- a/Sources/Puredux/Store/Core/StoreProtocol.swift
+++ b/Sources/Puredux/Store/Core/StoreProtocol.swift
@@ -28,4 +28,14 @@ extension StoreProtocol {
     func subscribe(observer: Observer<State>) {
         subscribe(observer: observer, receiveCurrentState: true)
     }
+    
+    func weakRefStore() -> Store<State, Action> {
+        Store(dispatch: { [weak self] in self?.dispatch($0) },
+              subscribe: { [weak self] in self?.subscribe(observer: $0) }
+        )
+    }
+    
+    func strongRefStore() -> Store<State, Action> {
+        Store<State, Action>(storeObject: self)
+    }
 }

--- a/Sources/Puredux/Store/Core/StoreProtocol.swift
+++ b/Sources/Puredux/Store/Core/StoreProtocol.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol StoreProtocol {
+protocol StoreProtocol<State, Action>: AnyObject {
     associatedtype Action
     associatedtype State
 
@@ -22,4 +22,10 @@ protocol StoreProtocol {
     func subscribe(observer: Observer<State>, receiveCurrentState: Bool)
 
     func dispatch(scopedAction: ScopedAction<Action>)
+}
+
+extension StoreProtocol {
+    func subscribe(observer: Observer<State>) {
+        subscribe(observer: observer, receiveCurrentState: true)
+    }
 }

--- a/Sources/Puredux/Store/Core/VoidStore.swift
+++ b/Sources/Puredux/Store/Core/VoidStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct VoidStore<Action>: StoreProtocol {
+final class VoidStore<Action>: StoreProtocol {
     let currentState: Void = Void()
     let actionsInterceptor: ActionsInterceptor<Action>?
 
@@ -18,4 +18,8 @@ struct VoidStore<Action>: StoreProtocol {
     func subscribe(observer: Observer<()>, receiveCurrentState: Bool) { }
 
     func dispatch(scopedAction: ScopedAction<Action>) { }
+    
+    init(actionsInterceptor: ActionsInterceptor<Action>? = nil) {
+        self.actionsInterceptor = actionsInterceptor
+    }
 }

--- a/Sources/Puredux/Store/Store.swift
+++ b/Sources/Puredux/Store/Store.swift
@@ -129,10 +129,7 @@ extension Store {
     func weakRefStore() -> Store<State, Action> {
         switch storeType {
         case .storeObject(let referencedStore):
-            return Store(
-                dispatch: { [weak referencedStore] in referencedStore?.dispatch($0) },
-                subscribe: { [weak referencedStore] in referencedStore?.subscribe(observer: $0) }
-            )
+            return referencedStore.weakRefStore()
         case .store:
             return self
         }


### PR DESCRIPTION
Internals refactoring. Replaced referenced store object proxy with `StoreNode` covered under `StoreProtocol`