### PR TITLE
Added State Store

### DIFF
--- a/Sources/Puredux/Store/Core/StoreProtocol.swift
+++ b/Sources/Puredux/Store/Core/StoreProtocol.swift
@@ -35,7 +35,7 @@ extension StoreProtocol {
         )
     }
     
-    func strongRefStore() -> Store<State, Action> {
-        Store<State, Action>(storeObject: self)
+    func stateStore() -> StateStore<State, Action> {
+        StateStore<State, Action>(storeObject: self)
     }
 }

--- a/Sources/Puredux/Store/StateStore.swift
+++ b/Sources/Puredux/Store/StateStore.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 
+@available(*, deprecated, renamed: "StateStore", message: "Will be removed in the next major release. StateStore is a former StoreObject replacement")
+public typealias StoreObject = StateStore
+
 public struct StateStore<State, Action> {
     let storeObject: any StoreProtocol<State, Action>
     

--- a/Sources/Puredux/Store/StateStore.swift
+++ b/Sources/Puredux/Store/StateStore.swift
@@ -1,0 +1,26 @@
+//
+//  File.swift
+//  
+//
+//  Created by Sergey Kazakov on 04/04/2024.
+//
+
+import Foundation
+
+public struct StateStore<State, Action> {
+    let storeObject: any StoreProtocol<State, Action>
+    
+    public func store() -> Store<State, Action> {
+        Store<State, Action>(
+            dispatcher: { [weak storeObject] in storeObject?.dispatch($0) },
+            subscribe: { [weak storeObject] in storeObject?.subscribe(observer: $0) })
+    }
+    
+    public func dispatch(_ action: Action) {
+        storeObject.dispatch(action)
+    }
+    
+    public func subscribe(observer: Observer<State>) {
+        storeObject.subscribe(observer: observer)
+    }
+}

--- a/Sources/Puredux/Store/Store.swift
+++ b/Sources/Puredux/Store/Store.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-@available(*, deprecated, renamed: "StateStore", message: "Will be removed in the next major release. Feel free to rename StoreObject to StateStore")
-public typealias StoreObject = StateStore
 
 public extension Store {
     

--- a/Sources/Puredux/Store/StoreFactory.swift
+++ b/Sources/Puredux/Store/StoreFactory.swift
@@ -110,7 +110,7 @@ public extension StoreFactory {
         qos: DispatchQoS = .userInteractive,
         reducer: @escaping Reducer<ChildState, Action>) ->
 
-    Store<LocalState, Action> {
+    StateStore<LocalState, Action> {
 
         rootStoreNode.createChildStore(
             initialState: initialState,
@@ -118,7 +118,7 @@ public extension StoreFactory {
             qos: qos,
             reducer: reducer
         )
-        .strongRefStore()
+        .stateStore()
     }
 
     /// Initializes a new child store with initial state
@@ -151,7 +151,7 @@ public extension StoreFactory {
     func childStore<ChildState>(
         initialState: ChildState,
         qos: DispatchQoS = .userInteractive,
-        reducer: @escaping Reducer<ChildState, Action>) -> Store<(State, ChildState), Action> {
+        reducer: @escaping Reducer<ChildState, Action>) -> StateStore<(State, ChildState), Action> {
 
             childStore(initialState: initialState,
                        stateMapping: { state, childState in (state, childState) },

--- a/Sources/Puredux/Store/StoreFactory.swift
+++ b/Sources/Puredux/Store/StoreFactory.swift
@@ -78,14 +78,14 @@ public extension StoreFactory {
         rootStoreNode.weakRefStore().scope(toOptional: localState)
     }
 
-    /// Initializes a new child store with initial state
+    /// Initializes a new child StateStore with initial state
     ///
-    /// - Returns: Child Store
+    /// - Returns: Child StateStore
     ///
     /// ChildStore is a composition of root store and newly created local store.
     /// Local state is a mapping of the child state and root store's state.
     ///
-    /// ChildStore's lifecycle along with its ChildState is determined by Store's lifecycle.
+    /// ChildStore's lifecycle along with its Child's State is determined by StateStore's lifecycle.
     ///
     /// RootStore vs ChildStore Action Dispatch
     ///
@@ -121,14 +121,14 @@ public extension StoreFactory {
         .stateStore()
     }
 
-    /// Initializes a new child store with initial state
+    /// Initializes a new child StateStore with initial state
     ///
-    /// - Returns: Child Store
+    /// - Returns: Child StateStore
     ///
     /// ChildStore is a composition of root store and newly created local store.
-    /// Child state is a mapping of the local state and root store's state.
+    /// Local state is a mapping of the child state and root store's state.
     ///
-    /// ChildStore's lifecycle along with its LocalState is determined by Store's lifecycle.
+    /// ChildStore's lifecycle along with its Child's State is determined by StateStore's lifecycle.
     ///
     /// RootStore vs ChildStore Action Dispatch
     ///

--- a/Sources/Puredux/SwiftUI/Store/PublishingStoreObject.swift
+++ b/Sources/Puredux/SwiftUI/Store/PublishingStoreObject.swift
@@ -13,7 +13,7 @@ import Combine
 ///
 @available(iOS 13.0, *)
 public struct PublishingStoreObject<AppState, Action> {
-    private let undelyingStore: Store<AppState, Action>
+    private let stateStore: StateStore<AppState, Action>
     private let stateSubject: PassthroughSubject<AppState, Never>
 
     /// Initializes a new PublishingStoreObject
@@ -28,9 +28,9 @@ public struct PublishingStoreObject<AppState, Action> {
     /// For all other cases, EnvStoreFactory's methods should be used to create viable PublishingStoreObject.
     ///
     ///
-    @available(*, deprecated, renamed: "init(store:)", message: "Will be removed in the next major release.")
-    public init(storeObject: Store<AppState, Action>) {
-        self.undelyingStore = storeObject
+    @available(*, deprecated, renamed: "init(stateStore:)", message: "Will be removed in the next major release.")
+    public init(storeObject: StoreObject<AppState, Action>) {
+        self.stateStore = storeObject
         self.stateSubject = PassthroughSubject<AppState, Never>()
         storeObject.subscribe(observer: asObserver)
     }
@@ -46,10 +46,10 @@ public struct PublishingStoreObject<AppState, Action> {
     ///
     /// For all other cases, EnvStoreFactory's methods should be used to create viable PublishingStoreObject.
     ///
-    public init(store: Store<AppState, Action>) {
-        self.undelyingStore = store
+    public init(stateStore: StateStore<AppState, Action>) {
+        self.stateStore = stateStore
         self.stateSubject = PassthroughSubject<AppState, Never>()
-        store.subscribe(observer: asObserver)
+        stateStore.subscribe(observer: asObserver)
     }
 }
 
@@ -64,7 +64,7 @@ public extension PublishingStoreObject {
     /// PublishingStore is thread safe. Actions can be safely dispatched from any thread.
     ///
     func store() -> PublishingStore<AppState, Action> {
-        let store = undelyingStore.weakRefStore()
+        let store = stateStore.store()
         return PublishingStore(
             statePublisher: statePublisher(),
             dispatch: { store.dispatch($0) }
@@ -79,7 +79,7 @@ private extension PublishingStoreObject {
     }
 
     func dispatch(_ action: Action) {
-        undelyingStore.dispatch(action)
+        stateStore.dispatch(action)
     }
 }
 

--- a/Sources/Puredux/SwiftUI/StoreFactory/EnvStoreFactory.swift
+++ b/Sources/Puredux/SwiftUI/StoreFactory/EnvStoreFactory.swift
@@ -128,7 +128,7 @@ extension EnvStoreFactory {
     PublishingStoreObject<LocalState, Action> {
 
         PublishingStoreObject(
-            store: storeFactory.childStore(
+            stateStore: storeFactory.childStore(
                 initialState: initialState,
                 stateMapping: stateMapping,
                 qos: qos,
@@ -172,7 +172,7 @@ extension EnvStoreFactory {
     PublishingStoreObject<(AppState, ChildState), Action> {
 
         PublishingStoreObject(
-            store: storeFactory.childStore(
+            stateStore: storeFactory.childStore(
                 initialState: initialState,
                 qos: qos,
                 reducer: reducer

--- a/Tests/PureduxTests/StoreTests/StoreNodeTests/StoreNodeDetachedStoreRefCyclesTests.swift
+++ b/Tests/PureduxTests/StoreTests/StoreNodeTests/StoreNodeDetachedStoreRefCyclesTests.swift
@@ -39,7 +39,7 @@ final class StoreNodeChildStoreRefCyclesTests: XCTestCase {
 
     func test_WhenStoreObject_ThenStrongRefToChildStoreCreated() {
         weak var weakChildStore: ChildStore?
-        var referencedStore: Store<StateComposition, Action>?
+        var referencedStore: StateStore<StateComposition, Action>?
 
         autoreleasepool {
             let strongChildStore = rootStore.createChildStore(
@@ -51,7 +51,7 @@ final class StoreNodeChildStoreRefCyclesTests: XCTestCase {
             )
 
             weakChildStore = strongChildStore
-            referencedStore = strongChildStore.strongRefStore()
+            referencedStore = strongChildStore.stateStore()
         }
 
         XCTAssertNotNil(weakChildStore)
@@ -59,7 +59,7 @@ final class StoreNodeChildStoreRefCyclesTests: XCTestCase {
 
     func test_WhenStoreObjectReleased_ThenChildStoreIsReleased() {
         weak var weakChildStore: ChildStore?
-        var referencedStore: Store<StateComposition, Action>?
+        var referencedStore: StateStore<StateComposition, Action>?
 
         autoreleasepool {
             let strongChildStore = rootStore.createChildStore(
@@ -71,7 +71,7 @@ final class StoreNodeChildStoreRefCyclesTests: XCTestCase {
             )
 
             weakChildStore = strongChildStore
-            referencedStore = strongChildStore.strongRefStore()
+            referencedStore = strongChildStore.stateStore()
         }
 
         referencedStore = nil

--- a/Tests/PureduxTests/StoreTests/StoreNodeTests/StoreNodeObserverRefCycleTests.swift
+++ b/Tests/PureduxTests/StoreTests/StoreNodeTests/StoreNodeObserverRefCycleTests.swift
@@ -33,7 +33,7 @@ final class StoreNodeChildStoreObserverRefCycleTests: XCTestCase {
             weakRefObject = object
             weakChildStore = store
 
-            let referencedStore = store.strongRefStore()
+            let referencedStore = store.stateStore()
 
             let observer = Observer<ReferenceTypeState> { _, complete in
                 referencedStore.dispatch(UpdateIndex(index: 1))
@@ -64,7 +64,7 @@ final class StoreNodeChildStoreObserverRefCycleTests: XCTestCase {
             weakRefObject = object
             weakChildStore = store
 
-            let referencedStore = store.strongRefStore()
+            let referencedStore = store.stateStore()
 
             let observer = Observer<ReferenceTypeState> { _, complete in
                 referencedStore.dispatch(UpdateIndex(index: 1))

--- a/Tests/PureduxTests/StoreTests/StoreNodeTests/StoreNodeRefCyclesTests.swift
+++ b/Tests/PureduxTests/StoreTests/StoreNodeTests/StoreNodeRefCyclesTests.swift
@@ -30,7 +30,7 @@ final class StoreNodeRootStoreRefCyclesTests: XCTestCase {
     
     func test_WhenStoreExists_ThenStrongRefToRootCreated() {
         weak var weakRootStore: RootStoreNode<TestState, Action>?
-        var store: Store<TestState, Action>?
+        var store: StateStore<TestState, Action>?
         
         autoreleasepool {
             let rootStore = RootStoreNode<TestState, Action>.initRootStore(
@@ -40,7 +40,7 @@ final class StoreNodeRootStoreRefCyclesTests: XCTestCase {
                 }
             
             weakRootStore = rootStore
-            store = rootStore.strongRefStore()
+            store = rootStore.stateStore()
         }
         
         XCTAssertNotNil(weakRootStore)
@@ -48,7 +48,7 @@ final class StoreNodeRootStoreRefCyclesTests: XCTestCase {
     
     func test_WhenStoreRemoved_ThenRootStoreIsReleased() {
         weak var weakRootStore: RootStoreNode<TestState, Action>?
-        var store: Store<TestState, Action>?
+        var store: StateStore<TestState, Action>?
         
         autoreleasepool {
             let rootStore = RootStoreNode<TestState, Action>.initRootStore(
@@ -58,7 +58,7 @@ final class StoreNodeRootStoreRefCyclesTests: XCTestCase {
                 }
             
             weakRootStore = rootStore
-            store = rootStore.strongRefStore()
+            store = rootStore.stateStore()
         }
         
         XCTAssertNotNil(weakRootStore)

--- a/Tests/PureduxTests/UIKitTests/ChildStorePresenterTests/NoDeduplicationPropsStoreObjectTests.swift
+++ b/Tests/PureduxTests/UIKitTests/ChildStorePresenterTests/NoDeduplicationPropsStoreObjectTests.swift
@@ -22,7 +22,7 @@ final class PropsEvaluationWithChildStoreTests: XCTestCase {
             })
     }()
 
-    lazy var store: Store<(TestAppStateWithIndex, SubStateWithTitle), Action> = {
+    lazy var store: StateStore<(TestAppStateWithIndex, SubStateWithTitle), Action> = {
         factory.childStore(
             initialState: SubStateWithTitle(title: "title"),
             reducer: { state, action in state.reduce(action) }


### PR DESCRIPTION
The idea of having a single Store type for everything didn't take off.
Getting back to 2 kinds of stores: `Store<State, Action>` and `StateStore<State, Action>`.

- `StateStore` owns the local state
- `Store` doesn't own anything, but provides an interface to other stores