### PR TITLE
Compiler crash fix

### DIFF
--- a/Sources/Puredux/SideEffects/CancellableObserver.swift
+++ b/Sources/Puredux/SideEffects/CancellableObserver.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 final class CancellableObserver {
-    private class AnyStateObserver { }
+    private final class AnyStateObserver: Sendable { }
 
-    var observer: AnyObject = AnyStateObserver()
+    var observer: AnyObject & Sendable = AnyStateObserver()
 
     init(_ observer: AnyObject) {
         self.observer = observer

--- a/Tests/PureduxTests/StoreTests/RootStoreTests/RootStoreQueueTests.swift
+++ b/Tests/PureduxTests/StoreTests/RootStoreTests/RootStoreQueueTests.swift
@@ -98,7 +98,7 @@ final class StateStoreQueueTests: XCTestCase {
             XCTAssertFalse(Thread.isMainThread)
             asyncExpectation.fulfill()
         }
-        action.dispatchQueue = .global(qos: .background)
+        action.dispatchQueue = .global(qos: .default)
         store.dispatch(action)
 
         waitForExpectations(timeout: timeout)

--- a/Tests/PureduxTests/StoreTests/StateStoreTests/FactoryRootStoreQueueTests.swift
+++ b/Tests/PureduxTests/StoreTests/StateStoreTests/FactoryRootStoreQueueTests.swift
@@ -77,7 +77,7 @@ final class FactoryStateStoreQueueTests: XCTestCase {
             asyncExpectation.fulfill()
         }
 
-        action.dispatchQueue = .global(qos: .background)
+        action.dispatchQueue = .global(qos: .default)
 
         store.dispatch(action)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make CancellableObserver’s internal types Sendable and switch test action dispatch queues to .global(qos: .default).
> 
> - **SideEffects (`Sources/Puredux/SideEffects/CancellableObserver.swift`)**:
>   - Make `AnyStateObserver` `final` and `Sendable`.
>   - Change `observer` type to `AnyObject & Sendable`.
> - **Tests**:
>   - `Tests/PureduxTests/StoreTests/RootStoreTests/RootStoreQueueTests.swift`
>     - Set `action.dispatchQueue` to `.global(qos: .default)`.
>   - `Tests/PureduxTests/StoreTests/StateStoreTests/FactoryRootStoreQueueTests.swift`
>     - Set `action.dispatchQueue` to `.global(qos: .default)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1c1fb8eb0d9c0398bf596796b76c9dbc483dc2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->